### PR TITLE
Update build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,28 @@ Installation
 ```{r}
 source("https://bioconductor.org/biocLite.R")
 biocLite("GenomicRanges")
+biocLite("DNAcopy")
 ```
 
 2. Install devtools from CRAN (if you don't have it already)
 
 ```{r}
-install.packages('devtools')
+install.packages('devtools')  
+install.packages('slam')  
+install.packages('Rcplex')  
+## Requires IBM ILOG CPLEX: install the community version, Download Rcplex source,
+## note the include dir, and build Rcplex from source if auto install fails
+## R CMD INSTALL --configure-args="--with-cplex-dir=/Applications/CPLEX_Studio_Community128/cplex" Rcplex_0.3-3.tar.gz
 ```
 
 3. Install dependent mskilab dependencies
 
 ```{r}
 devtools::install_github('mskilab/gUtils')
+devtools::install_github('gTrack')
 devtools::install_github('mskilab/gGnome')
 
 3. Install JaBbA
 
 ```{r}
-devtools::install_github('mskilab/JaBbA)
+devtools::install_github('mskilab/JaBbA')


### PR DESCRIPTION
I had some trouble with the build instructions in the README, so I went through the process of debugging it and arrived at what I think is a working version (though I haven't done anything more than load the package yet). I'm not sure how much of it might be OS X vs. Linux, but my guess is these fixes should be pretty universal for base R.