### PR TITLE
read.junctions modification

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Remotes:
   github::mskilab/gChain,
   github::mskilab/gGnome
 Depends:
-  R (>= 3.6.0),
+  R (>= 3.5.0),
   GenomicRanges,
   gUtils,
   gTrack,
@@ -40,4 +40,4 @@ Suggests:
   covr
 License: MIT + file LICENSE
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/R/JaBbA.R
+++ b/R/JaBbA.R
@@ -6274,7 +6274,7 @@ read.junctions = function(rafile,
 
             ln = readLines(ra.path)
             if (is.na(skip)){
-                nh = min(c(Inf, which(!grepl('^((#)|(chrom1))', ln))))-1
+                nh = min(c(Inf, which(!grepl('^((#)|(chrom1)|(chr1))', ln))))-1
                 if (is.infinite(nh)){
                     nh = 1
                 }
@@ -6295,17 +6295,25 @@ read.junctions = function(rafile,
                 rafile = fread(rafile, header = FALSE)
             } else {
 
-                rafile = tryCatch(fread(ra.path, header = FALSE, skip = nh), error = function(e) NULL)
+                if (nh == 1) {
+                    header_arg = TRUE
+                    skip_arg = 0
+                } else if (nh > 1) {
+                    header_arg = F
+                    skip_arg = nh
+                }
+
+                rafile = tryCatch(fread(ra.path, header = header_arg, skip = skip_arg), error = function(e) NULL)
                 if (is.null(rafile)){
-                    rafile = tryCatch(fread(ra.path, header = FALSE, skip = nh, sep = '\t'), error = function(e) NULL)
+                    rafile = tryCatch(fread(ra.path, header = header_arg, skip = skip_arg, sep = '\t'), error = function(e) NULL)
                 }
 
                 if (is.null(rafile)){
-                    rafile = tryCatch(fread(ra.path, header = FALSE, skip = nh, sep = ','), error = function(e) NULL)
+                    rafile = tryCatch(fread(ra.path, header = header_arg, skip = skip_arg, sep = ','), error = function(e) NULL)
                 }
 
                 if (is.null(rafile)){
-                    jerror('Error reading bedpe')
+                    stop('Error reading bedpe')
                 }
             }
 


### PR DESCRIPTION
Allow proper parsing of header line into columns for junctions provided in canonical BEDPE format.